### PR TITLE
Fix original project's compile error

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -4,6 +4,7 @@
 #include <string>
 #include <thread>
 
+#include <prometheus/counter.h>
 #include <prometheus/exposer.h>
 #include <prometheus/registry.h>
 


### PR DESCRIPTION
Fix the following compile error:

/usr/src/prometheus-cpp-example/main.cpp:22:39: error: 'BuildCounter' was not declared in this scope
   auto& counter_family = BuildCounter()
                                       ^
